### PR TITLE
Unify tese cleaning and document LLM configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 LLM_PROVIDER=openai
 LLM_MODEL=gpt-4.1-mini
 LLM_API_KEY=sk-your-key
-# Opcional: ajuste URL base se usar proxy ou Azure.
+# Opcional para proxies/self-host: ajuste a URL base.
 # LLM_BASE_URL=https://api.openai.com/v1/chat/completions

--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,11 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# Project artifacts
+runs/
+data/raw/
+reports/*.csv
+
 # Pyre type checker
 .pyre/
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ Crie um arquivo `.env` na raiz com as variáveis necessárias, por exemplo:
 LLM_API_KEY="sua-chave"
 LLM_PROVIDER="openai"
 LLM_MODEL="gpt-4.1-mini"
+# Opcional para proxies/self-host: LLM_BASE_URL="https://api.openai.com/v1/chat/completions"
 ```
 
 Os scripts carregarão essas variáveis automaticamente (`python-dotenv`). Configure temperatura `0.0`
-e `top_p=1.0` para reprodutibilidade.
+e `top_p=1.0` para reprodutibilidade. Caso utilize um proxy ou Azure OpenAI, ajuste `LLM_BASE_URL`.
 
 ## Fluxo de trabalho da POC
 
@@ -93,11 +94,14 @@ e `top_p=1.0` para reprodutibilidade.
    ```bash
    python scripts/make_ab_pairs.py --in data/curated/temas_seed.jsonl --out data/curated/ab_pairs.jsonl
    ```
-3. Rode o avaliador e experimento:
+3. Rode o avaliador e experimento (saída principal em Markdown, CSV opcional para análises):
    ```bash
-   python -m undogmatic.eval_ab --in data/curated/ab_pairs.jsonl --report reports/ab_test.md
+   python -m undogmatic.eval_ab --in data/curated/ab_pairs.jsonl --report reports/ab_test.md --csv reports/ab_results.csv
    ```
 4. Consulte `reports/ab_test.md` e os artefatos em `runs/<data>/` para análise completa.
+
+> `scripts/run_ab_test.py` permanece no repositório apenas por retrocompatibilidade; utilize o comando
+> `python -m undogmatic.eval_ab` descrito acima como caminho canônico.
 
 ## Testes
 

--- a/scripts/build_dataset.py
+++ b/scripts/build_dataset.py
@@ -9,7 +9,7 @@ from typing import Iterable, List, TypedDict
 
 from bs4 import BeautifulSoup
 
-from undogmatic.patterns import normalize_text, remove_authority_markers
+from undogmatic.utils import cleanse_tese, normalize_whitespace
 
 
 class TemaRecord(TypedDict):
@@ -36,7 +36,7 @@ def parse_stf_html(path: pathlib.Path) -> Iterable[TemaRecord]:
             tese_node = link.find_next("p")
             if tese_node is None:
                 continue
-            tese = normalize_text(_extract_text(tese_node))
+            tese = normalize_whitespace(_extract_text(tese_node))
             yield {
                 "court": "STF",
                 "tema": tema,
@@ -58,7 +58,7 @@ def parse_stj_html(path: pathlib.Path) -> Iterable[TemaRecord]:
             tese_node = header.find_next("p")
             if tese_node is None:
                 continue
-            tese = normalize_text(_extract_text(tese_node))
+            tese = normalize_whitespace(_extract_text(tese_node))
             link = header.find("a")
             url = link.get("href") if link else ""
             yield {
@@ -73,7 +73,7 @@ def build_ab_pairs(records: Iterable[TemaRecord]) -> List[dict]:
     ab_pairs = []
     for record in records:
         authority_only = f"{record['court']} Tema {record['tema']}"
-        explained_only = remove_authority_markers(record["tese"])
+        explained_only = cleanse_tese(record["tese"])
         ab_pairs.append(
             {
                 "id": f"{record['court']}-{record['tema']}",

--- a/scripts/make_ab_pairs.py
+++ b/scripts/make_ab_pairs.py
@@ -5,22 +5,9 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
-import re
 from typing import Iterable, Iterator
 
-THEME_PATTERN = re.compile(r"\bTema\s*(?:n[ºo]\s*)?\d{1,5}\b", flags=re.IGNORECASE)
-TRIBUNAL_PATTERN = re.compile(
-    r"\b(?:STF|STJ|Supremo Tribunal Federal|Superior Tribunal de Justiça)\b", flags=re.IGNORECASE
-)
-
-
-def cleanse_tese(text: str) -> str:
-    """Remove explicit tribunal/theme mentions while preserving substantive content."""
-
-    without_theme = THEME_PATTERN.sub("", text)
-    without_tribunal = TRIBUNAL_PATTERN.sub("", without_theme)
-    normalized = " ".join(without_tribunal.split())
-    return normalized.strip()
+from undogmatic.utils import cleanse_tese
 
 
 def load_seeds(path: pathlib.Path) -> Iterator[dict]:

--- a/undogmatic/llm_scorer.py
+++ b/undogmatic/llm_scorer.py
@@ -96,6 +96,7 @@ class LLMScorer:
         provider: Optional[str] = None,
         model: Optional[str] = None,
         api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
         log_dir: Path | str | None = None,
         max_retries: int = 2,
     ) -> None:
@@ -103,6 +104,7 @@ class LLMScorer:
         self.provider = provider or os.getenv("LLM_PROVIDER", "openai")
         self.model = model or os.getenv("LLM_MODEL")
         self.api_key = api_key or os.getenv("LLM_API_KEY")
+        self.base_url = base_url or os.getenv("LLM_BASE_URL")
         self.log_dir = Path(log_dir or "runs")
         self.log_dir.mkdir(parents=True, exist_ok=True)
         self.max_retries = max_retries
@@ -117,7 +119,7 @@ class LLMScorer:
             raise ValueError(f"Unsupported LLM provider: {self.provider}")
         if not self.api_key or not self.model:
             raise ValueError("LLM_API_KEY and LLM_MODEL must be set for OpenAI provider")
-        return OpenAIChatClient(api_key=self.api_key, model=self.model)
+        return OpenAIChatClient(api_key=self.api_key, model=self.model, base_url=self.base_url)
 
     def score_text(self, text: str, *, metadata: Optional[Dict[str, Any]] = None) -> ScoreResult:
         system_prompt = prompts.SYSTEM_PROMPT

--- a/undogmatic/utils.py
+++ b/undogmatic/utils.py
@@ -1,0 +1,29 @@
+"""Shared text cleaning utilities for thesis processing."""
+
+from __future__ import annotations
+
+import re
+
+THEME_PATTERN = re.compile(r"\bTema\s*(?:n[ºo]\s*)?\d{1,5}\b", flags=re.IGNORECASE)
+TRIBUNAL_PATTERN = re.compile(
+    r"\b(?:STF|STJ|Supremo Tribunal Federal|Superior Tribunal de Justiça)\b",
+    flags=re.IGNORECASE,
+)
+WHITESPACE_PATTERN = re.compile(r"\s+")
+
+__all__ = ["cleanse_tese", "normalize_whitespace"]
+
+
+def normalize_whitespace(text: str) -> str:
+    """Collapse repeated whitespace and trim the string."""
+
+    return WHITESPACE_PATTERN.sub(" ", text).strip()
+
+
+def cleanse_tese(text: str) -> str:
+    """Remove explicit tribunal/theme mentions while preserving substantive content."""
+
+    without_theme = THEME_PATTERN.sub("", text)
+    without_tribunal = TRIBUNAL_PATTERN.sub("", without_theme)
+    return normalize_whitespace(without_tribunal)
+


### PR DESCRIPTION
## Summary
- ignore transient run, raw data, and CSV report artifacts in version control
- document the standardized LLM environment variables and canonical evaluation command
- centralize tese cleansing utilities and allow configuring the LLM base URL in the scorer

## Testing
- pytest *(fails: missing pandas/requests in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d858de571083259affce8fba8fd970