### PR TITLE
Add on-disk cache for LLM scorer responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ do STF/STJ.
 2. **Geração A/B** (`scripts/make_ab_pairs.py`): cria pares `authority_only` vs. `explained_only`
 para cada tese.
 3. **ShameScore por LLM** (`undogmatic/llm_scorer.py`): envia o texto para um modelo de linguagem
-com um prompt ancorado em PT-BR e retorna `shame_score`, `confidence` e `rationale`.
+   com um prompt ancorado em PT-BR e retorna `shame_score`, `confidence` e `rationale`. As respostas
+   válidas são armazenadas em cache (`runs/cache/<sha1>.json`) para evitar chamadas repetidas.
 4. **Experimento pareado** (`undogmatic/eval_ab.py`): compara a distribuição do score entre os dois
 estilos e aplica Wilcoxon + tamanho de efeito.
 5. **Relatório** (`reports/ab_test.md`): consolida tabelas, gráficos e interpretação.
@@ -98,7 +99,8 @@ e `top_p=1.0` para reprodutibilidade. Caso utilize um proxy ou Azure OpenAI, aju
    ```bash
    python -m undogmatic.eval_ab --in data/curated/ab_pairs.jsonl --report reports/ab_test.md --csv reports/ab_results.csv
    ```
-4. Consulte `reports/ab_test.md` e os artefatos em `runs/<data>/` para análise completa.
+4. Consulte `reports/ab_test.md` e os artefatos em `runs/<data>/` para análise completa. Reutilize o
+   cache automático (`runs/cache/`) sempre que repetir o mesmo texto para economizar créditos.
 
 > `scripts/run_ab_test.py` permanece no repositório apenas por retrocompatibilidade; utilize o comando
 > `python -m undogmatic.eval_ab` descrito acima como caminho canônico.

--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -61,6 +61,8 @@ parsing fails.
 3. Call the provider with deterministic parameters (temperature 0.0, top_p 1.0).
 4. Parse JSON into a Pydantic model.
 5. Persist logs under `runs/YYYYMMDD/ID/` (prompt, raw response, parsed result).
+6. Cache successful responses as `runs/cache/<sha1>.json` keyed by the input text to avoid
+   unnecessary repeated calls.
 
 ### 3.3 Evaluation pipeline
 
@@ -100,8 +102,8 @@ power until more theses are added.
 multi-provider checks are necessary safeguards.
 - **Prompt gaming:** Although the prompt warns against hedge-spam, models might still be fooled by
 well-crafted rhetoric. Future work includes adversarial examples and human evaluation.
-- **Cost and latency:** API calls for every variant can be expensive. Distilling the signal into a
-cheaper embedding-based regressor is an optional follow-up (P5).
+- **Cost and latency:** API calls for every variant can be expensive. The scorer now caches hashes of
+  previous inputs to reuse results, but large batches will still benefit from distillation (P5).
 
 ## 6. Roadmap
 


### PR DESCRIPTION
Motivation
- Avoid repeated LLM calls for identical texts and reduce experiment costs.

Changes
- Add a SHA1-addressed cache directory under `runs/cache` that stores validated scorer outputs and marks cache hits in the interaction logs.
- Extend the scorer unit tests to ensure cached results are reused across scorer instances.
- Document the caching behaviour in the README and WHITEPAPER so operators know how to reuse existing scores.

How to test
- `uvx ruff format .`
- `uvx ruff check . --fix`
- `uv run pytest -q`

Risks / Limitations
- Cache keys use only the input text, so different metadata values will resolve to the same cached score.

Checklist
- [x] uvx ruff format .
- [x] uvx ruff check . --fix
- [x] uv run pytest -q
- [x] No secrets / large artifacts committed

------
https://chatgpt.com/codex/tasks/task_e_68d862f02ef88325bcd1c0e33cb53b9d