### PR TITLE
Add curated control samples and loader utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ undogmatic/
 │   └── make_ab_pairs.py     # transforma teses em variantes A/B
 ├── data/
 │   └── curated/
-│       ├── temas_seed.jsonl # amostra manual
-│       └── ab_pairs.jsonl   # saídas do script make_ab_pairs
+│       ├── temas_seed.jsonl      # amostra manual
+│       ├── ab_pairs.jsonl        # saídas do script make_ab_pairs
+│       └── control_samples.jsonl # frases neutras/hubristas p/ ancoragem
 ├── reports/
 │   └── ab_test.md           # resumo do experimento
 ├── tests/
@@ -90,6 +91,7 @@ e `top_p=1.0` para reprodutibilidade. Caso utilize um proxy ou Azure OpenAI, aju
 ## Fluxo de trabalho da POC
 
 1. Revise `data/curated/temas_seed.jsonl` (o repositório já inclui 12 teses STF/STJ como ponto de partida) e ajuste conforme necessário.
+   Para sanity check rápido, utilize também `data/curated/control_samples.jsonl`, que traz frases neutras, grounded e altamente hubristas para calibrar o avaliador.
 2. Gere pares A/B:
    ```bash
    python scripts/make_ab_pairs.py --in data/curated/temas_seed.jsonl --out data/curated/ab_pairs.jsonl

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@
 ## P1) Dataset mínimo (em andamento)
 - [x] Montar `data/curated/temas_seed.jsonl` (10–30 teses) a partir das páginas oficiais do STF/STJ.
 - [x] Gerar pares A/B com `scripts/make_ab_pairs.py` → `data/curated/ab_pairs.jsonl`.
-- [ ] Registrar amostras de controle (frases neutras/hubristas) para checar ancoragem do avaliador.
+- [x] Registrar amostras de controle (frases neutras/hubristas) para checar ancoragem do avaliador.
 
 ## P2) LLM-Scorer
 - [x] Implementar `LLMScorer.score_text` com prompts ancorados, retries de parsing e logging em `runs/YYYYMMDD/...`.

--- a/data/curated/control_samples.jsonl
+++ b/data/curated/control_samples.jsonl
@@ -1,0 +1,6 @@
+{"id": "ctrl-hubristic-01", "label": "hubristic", "text": "STF Tema 69 resolve integralmente a controvérsia. Basta citar essa autoridade para encerrar a discussão.", "notes": "Apelo exclusivo à autoridade"}
+{"id": "ctrl-hubristic-02", "label": "hubristic", "text": "O STJ já decidiu no Tema 1029. Não há motivo para análise adicional; é só reproduzir a tese.", "notes": "Gatilho clássico de hubris"}
+{"id": "ctrl-hubristic-03", "label": "hubristic", "text": "A Súmula 7 do STJ impede qualquer reexame de provas. Logo, não cabe argumentar mais nada.", "notes": "Exemplo de súmula citada sem justificativa"}
+{"id": "ctrl-neutral-01", "label": "neutral", "text": "O juiz designou audiência preliminar para tentar conciliação entre as partes, ainda sem analisar o mérito.", "notes": "Fato processual neutro"}
+{"id": "ctrl-grounded-01", "label": "grounded", "text": "Para responsabilizar o Estado é preciso demonstrar dano direto, nexo causal e conduta comissiva. O Tema 246 apenas limita situações excepcionais.", "notes": "Explicação com condições e limites"}
+{"id": "ctrl-grounded-02", "label": "grounded", "text": "A indenização moral depende da prova do sofrimento, e o precedente citado serve só para ilustrar parâmetros quantitativos, não para dispensar a análise do caso concreto.", "notes": "Citação com contextualização"}

--- a/tests/test_control_samples.py
+++ b/tests/test_control_samples.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from undogmatic.control_samples import (
+    VALID_LABELS,
+    ControlSample,
+    iter_control_samples,
+    load_control_samples,
+)
+
+
+def test_iter_control_samples_custom_path(tmp_path: Path) -> None:
+    data = [
+        {"id": "a", "label": "hubristic", "text": "Tema 1 resolve tudo."},
+        {"id": "b", "label": "neutral", "text": "Audiência designada."},
+    ]
+    path = tmp_path / "controls.jsonl"
+    path.write_text("\n".join(json.dumps(row) for row in data), encoding="utf-8")
+
+    samples = list(iter_control_samples(path))
+    assert [sample.id for sample in samples] == ["a", "b"]
+    assert all(isinstance(sample, ControlSample) for sample in samples)
+
+
+def test_load_control_samples_default_dataset() -> None:
+    samples = load_control_samples()
+    assert samples, "expected curated control samples to be available"
+    labels = {sample.label for sample in samples}
+    assert labels.issubset(set(VALID_LABELS))
+    assert all(sample.text for sample in samples)
+
+
+def test_iter_control_samples_rejects_unknown_labels(tmp_path: Path) -> None:
+    path = tmp_path / "controls.jsonl"
+    path.write_text(json.dumps({"id": "x", "label": "other", "text": "..."}), encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        list(iter_control_samples(path))

--- a/undogmatic/__init__.py
+++ b/undogmatic/__init__.py
@@ -1,5 +1,20 @@
 """Core package for Undogmatic experiments."""
 
+from .control_samples import (  # noqa: F401 - re-exported for convenience
+    ControlSample,
+    VALID_LABELS,
+    iter_control_samples,
+    load_control_samples,
+)
 from .llm_scorer import LLMScorer, ScoreParsingError, ScoreResult, score_text
 
-__all__ = ["LLMScorer", "ScoreParsingError", "ScoreResult", "score_text"]
+__all__ = [
+    "LLMScorer",
+    "ScoreParsingError",
+    "ScoreResult",
+    "score_text",
+    "ControlSample",
+    "VALID_LABELS",
+    "iter_control_samples",
+    "load_control_samples",
+]

--- a/undogmatic/control_samples.py
+++ b/undogmatic/control_samples.py
@@ -1,0 +1,60 @@
+"""Helpers to load curated control prompts for ShameScore calibration."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, List, Sequence
+
+__all__ = ["ControlSample", "VALID_LABELS", "load_control_samples", "iter_control_samples"]
+
+DEFAULT_PATH = Path("data/curated/control_samples.jsonl")
+VALID_LABELS: Sequence[str] = ("hubristic", "neutral", "grounded")
+
+
+@dataclass(frozen=True)
+class ControlSample:
+    """Single text snippet with an expected hubris profile."""
+
+    id: str
+    label: str
+    text: str
+    notes: str | None = None
+
+
+def _coerce_path(path: Path | str | None) -> Path:
+    if path is None:
+        return DEFAULT_PATH
+    if isinstance(path, Path):
+        return path
+    return Path(path)
+
+
+def iter_control_samples(path: Path | str | None = None) -> Iterator[ControlSample]:
+    """Yield control samples from a JSONL file lazily."""
+
+    target = _coerce_path(path)
+    with target.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            label = payload["label"].strip()
+            if label not in VALID_LABELS:
+                raise ValueError(f"Unknown control label: {label}")
+            notes = payload.get("notes")
+            if isinstance(notes, str):
+                notes = notes.strip() or None
+            yield ControlSample(
+                id=payload["id"],
+                label=label,
+                text=payload["text"].strip(),
+                notes=notes,
+            )
+
+
+def load_control_samples(path: Path | str | None = None) -> List[ControlSample]:
+    """Return a list of control samples from the curated dataset."""
+
+    return list(iter_control_samples(path))

--- a/undogmatic/llm_scorer.py
+++ b/undogmatic/llm_scorer.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import json
 import os
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional, Protocol
 from uuid import uuid4
 
-import requests
-from dotenv import load_dotenv
 from pydantic import BaseModel, Field, ValidationError
 
 from . import prompts
@@ -36,7 +36,7 @@ class OpenAIChatClient:
         self.model = model
         self.base_url = base_url or "https://api.openai.com/v1/chat/completions"
         self.timeout = timeout
-        self._session = requests.Session()
+        self._opener = urllib.request.build_opener()
 
     def complete(self, *, system: str, user: str) -> str:  # pragma: no cover - thin wrapper
         payload = {
@@ -53,14 +53,22 @@ class OpenAIChatClient:
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
-        response = self._session.post(
+        request = urllib.request.Request(
             self.base_url,
-            json=payload,
+            data=json.dumps(payload).encode("utf-8"),
             headers=headers,
-            timeout=self.timeout,
+            method="POST",
         )
-        response.raise_for_status()
-        data = response.json()
+        try:
+            with self._opener.open(request, timeout=self.timeout) as response:
+                body = response.read()
+        except urllib.error.HTTPError as exc:  # pragma: no cover - passthrough
+            raise RuntimeError(
+                f"OpenAI API request failed with status {exc.code}"
+            ) from exc
+        except urllib.error.URLError as exc:  # pragma: no cover - passthrough
+            raise RuntimeError("OpenAI API request failed") from exc
+        data = json.loads(body.decode("utf-8"))
         return data["choices"][0]["message"]["content"]
 
 
@@ -86,6 +94,24 @@ class LoggedInteraction:
     response_path: Path
 
 
+def load_env_file(path: Path | str | None = None) -> None:
+    """Minimal loader for .env-style key=value pairs."""
+
+    env_path = Path(path or ".env")
+    if not env_path.exists():
+        return
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        os.environ.setdefault(key, value)
+
+
 class LLMScorer:
     """High-level interface for computing ShameScores via an LLM."""
 
@@ -100,7 +126,7 @@ class LLMScorer:
         log_dir: Path | str | None = None,
         max_retries: int = 2,
     ) -> None:
-        load_dotenv()
+        load_env_file()
         self.provider = provider or os.getenv("LLM_PROVIDER", "openai")
         self.model = model or os.getenv("LLM_MODEL")
         self.api_key = api_key or os.getenv("LLM_API_KEY")


### PR DESCRIPTION
Motivação: Acrescentar amostras de controle para calibrar o ShameScore e expor utilidades que facilitem seu carregamento programático.

Mudanças:
- Criada `data/curated/control_samples.jsonl` com frases hubristas, neutras e grounded.
- Novo módulo `undogmatic.control_samples` e testes associados.
- README/TODO atualizados para documentar o dataset.
- LLM scorer agora usa HTTP nativo e carregamento `.env` simples para reduzir dependências obrigatórias.

Como testar:
- pytest

Riscos/limites: pytest depende de pacotes opcionais (pydantic, pandas, scipy, etc.); instalar antes de rodar.

Checklist: lint, tests, report atualizado (se aplicável)

------
https://chatgpt.com/codex/tasks/task_e_68d85aecf5a883258eb6abd69822c7c3