### PR TITLE
Support injected scorer in eval_ab pipeline

### DIFF
--- a/tests/test_eval_ab.py
+++ b/tests/test_eval_ab.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 import pandas as pd
 
@@ -21,7 +23,9 @@ class StaticClient:
 def test_score_pairs_creates_csv(tmp_path: Path) -> None:
     scorer = LLMScorer(client=StaticClient(50.0), log_dir=tmp_path)
     pairs = [ABPair(id="X", authority_only="A", explained_only="B")]
-    df, csv_path = score_pairs(pairs, scorer, run_label="unit-test")
+    df, csv_path = score_pairs(
+        pairs, scorer.score_text, run_label="unit-test", log_dir=scorer.log_dir
+    )
 
     assert csv_path.exists()
     assert "unit-test" in csv_path.name
@@ -36,9 +40,8 @@ def test_compute_summary_handles_empty_dataframe() -> None:
     assert pd.isna(summary.rank_biserial)
 
 
-def test_run_writes_report_and_csv(tmp_path: Path) -> None:
-    ab_path = tmp_path / "pairs.jsonl"
-    ab_path.write_text(
+def _write_pairs(path: Path) -> None:
+    path.write_text(
         "\n".join(
             [
                 json.dumps({"id": "1", "authority_only": "A", "explained_only": "B"}),
@@ -47,20 +50,54 @@ def test_run_writes_report_and_csv(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def test_run_with_injected_scorer(tmp_path: Path) -> None:
+    ab_path = tmp_path / "pairs.jsonl"
+    _write_pairs(ab_path)
     report_path = tmp_path / "report.md"
     csv_path = tmp_path / "results.csv"
     scorer = LLMScorer(client=StaticClient(40.0), log_dir=tmp_path / "runs")
 
-    df, summary, generated_csv = run(
-        ab_path,
-        report_path=report_path,
-        csv_path=csv_path,
-        scorer=scorer,
-        run_label="integration",
-    )
+    with patch("undogmatic.eval_ab._get_scorer", side_effect=AssertionError):
+        df, summary, generated_csv = run(
+            ab_path,
+            report_path=report_path,
+            csv_path=csv_path,
+            scorer=scorer,
+            run_label="integration",
+        )
 
     assert report_path.exists()
     assert csv_path.exists()
     assert generated_csv.exists()
     assert len(df) == 2
     assert summary.authority_mean == summary.explained_mean == 40.0
+    assert (tmp_path / "runs").is_dir()
+    assert scorer.log_dir in generated_csv.parents
+
+
+def test_run_uses_default_backend_when_no_scorer(tmp_path: Path) -> None:
+    ab_path = tmp_path / "pairs.jsonl"
+    _write_pairs(ab_path)
+
+    def fake_scorer(text: str, metadata: dict | None = None) -> dict:
+        variant = metadata.get("variant") if metadata else None
+        score = 60 if variant == "authority_only" else 40
+        return {"shame_score": score, "confidence": 99, "rationale": "stub"}
+
+    with patch("undogmatic.eval_ab._get_scorer", return_value=fake_scorer) as mock_get:
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            df, summary, generated_csv = run(ab_path)
+        finally:
+            os.chdir(cwd)
+
+    assert mock_get.called
+    assert not df.empty
+    assert summary.authority_mean == 60
+    assert summary.explained_mean == 40
+    assert (tmp_path / "runs").is_dir()
+    resolved_csv = generated_csv if generated_csv.is_absolute() else (tmp_path / generated_csv)
+    assert resolved_csv.is_relative_to(tmp_path / "runs")


### PR DESCRIPTION
Motivação: Permitir que o pipeline A/B aceite scorers customizados sem depender exclusivamente do backend configurado.

Mudanças:
- Ajusta `run` para aceitar scorer injetado, reaproveitando seu `log_dir` e normalizando payloads retornados.
- Adiciona coercão de resultados em `score_pairs` para lidar com objetos `ScoreResult`.
- Amplia os testes para cobrir tanto o caminho com scorer injetado quanto o fallback do backend padrão.

Como testar:
- pytest

Riscos/limites: Assumimos que scorers customizados expõem `score_text` ou são chamáveis e retornam payloads tipo dicionário.

Checklist:
- [x] tests
- [ ] lint
- [ ] report atualizado

------
https://chatgpt.com/codex/tasks/task_e_68d974326760832591ad2dc1dc4cd91d